### PR TITLE
Documentation for overriding CLI defaults 

### DIFF
--- a/_development/linking.md
+++ b/_development/linking.md
@@ -1,6 +1,6 @@
 ---
 title: "Linking"
-order: 300
+order: 400
 ---
 
 Convox allows you to link containers by declaring associations in the `docker-compose.yml` manifest. Links are created by injecting environment variables that point at the linked container.

--- a/_development/overriding-cli-defaults.md
+++ b/_development/overriding-cli-defaults.md
@@ -1,0 +1,21 @@
+---
+title: "Overriding CLI defaults"
+order: 300
+---
+
+The following files may be used to override CLI defaults:
+
+- `.convox/app`
+    The contents of this file will be used as the default app name.
+
+    Example file contents: `myapp`
+
+    <div class="block-callout block-show-callout type-info" markdown="1">
+    Convox will use this value instead of inferring the app name from the current directory name.
+    </div>
+
+- `.convox/sync`
+    Synchronize local file changes into the running containers.
+
+    Valid options: `true`, `false`
+


### PR DESCRIPTION
Documents `.convox/app` and `.convox/sync`.