### PR TITLE
Docs search

### DIFF
--- a/_includes/google-cse.html
+++ b/_includes/google-cse.html
@@ -1,0 +1,11 @@
+<script>
+  (function() {
+    var cx = '007111823288829109980:hjlhpuowqyi';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -10,6 +10,8 @@ layout: base
 
 <div class="container subnav-content" role="main">
   <section id="toc" class="col-md-3 col-lg-3 visible-md-block visible-lg-block">
+    <gcse:search></gcse:search>
+
     {% for collection in site.collections %}
       {% if collection.label != "posts" %}
         <div class="collection">
@@ -37,3 +39,5 @@ layout: base
     </div>
   </section>
 </div>
+
+{% include google-cse.html %}

--- a/assets/css/convox.css
+++ b/assets/css/convox.css
@@ -85,7 +85,7 @@ pre {
   #subnav {
     margin-top: 0px !important;
   }
-  
+
   .content h3 {
     margin-top: 30px !important;
   }
@@ -184,7 +184,7 @@ pre {
   font-size: 1.3em;
 }
 
-html{ 
+html{
   position: relative;
   min-height: 100%;
   height: 100%;
@@ -1081,4 +1081,13 @@ p.api-button {
 
 #jobs li {
   margin-bottom: 8px;
+}
+
+input.gsc-input,
+.gsc-input-box,
+.gsc-input-box-hover,
+.gsc-input-box-focus,
+.gsc-search-button {
+    box-sizing: content-box;
+    line-height: normal;
 }


### PR DESCRIPTION
Docs search using Google Custom Search.

Currently this is referencing a Google CSE ID in my account but I’m
happy to transfer or switch out the ID.

I looked at Jekyll based search approaches, but Github Pages disallows
most plugins.

Closes #123.