### PR TITLE
Add back missing /docs TOC dropdown on mobile

### DIFF
--- a/_includes/subnav-docs.html
+++ b/_includes/subnav-docs.html
@@ -1,0 +1,40 @@
+<ul class="nav nav-tabs container">
+	<li><h2>Convox Documentation</h2></li>
+	<li class="pull-right visible-md-block visible-lg-block"><h2 id="version"></h2></li>
+	<li class="pull-right visible-xs-block visible-sm-block">
+		<div class="btn-group visible-xs-block visible-sm-block pull-right" id="toc-collapsed">
+			<button id="toc-toggle" type="button" class="btn btn-xs btn-default dropdown-toggle"
+				data-toggle="dropdown" aria-expanded="false" aria-haspopup="true">
+				<span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+				<span class="caret"></span>
+			</button>
+			<ul class="dropdown-menu docs-index">
+				{% for collection in site.collections %}
+					{% if collection.label != "posts" %}
+						<li class="dropdown-header">{{ collection.title }}</li>
+						{% assign pages = collection.docs | sort: 'order' %}
+						{% for page in pages %}
+							<li><a href="{{ page.url }}"><span>{{ page.title }}</span></a></li>
+						{% endfor %}
+					{% endif %}
+				{% endfor %}
+			</ul>
+		</div>
+	</li>
+</ul>
+
+<script>
+	$(window).ready(function() {
+		$.getJSON('http://convox.s3.amazonaws.com/release/versions.json', function(versions) {
+			versions.sort(function(a, b) {
+				return b.version.localeCompare(a.version);
+			});
+			for (var i in versions) {
+				if (versions[i].published) {
+					$('#version').text(versions[i].version);
+					return
+				}
+			}
+		});
+	});
+</script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,9 +3,7 @@ layout: base
 ---
 
 <div id="subnav" class="container">
-	<ul class="nav nav-tabs container">
-		<li><h2><a href="/blog">Convox Documentation</a></h2></li>
-	</ul>
+  {% include subnav-docs.html %}
 </div>
 
 <div class="container subnav-content" role="main">


### PR DESCRIPTION
## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack

TOC dropdown was unintentionally removed in a layouts cleanup in 4205fc3