### PR TITLE
set WordPress DB env vars before deploying

### DIFF
--- a/_languages/wordpress.md
+++ b/_languages/wordpress.md
@@ -35,12 +35,6 @@ The [official WordPress image from Docker Hub](https://hub.docker.com/_/wordpres
 
 The `volumes` directive will persist all of your WordPress files to a [network filesystem associated with your Rack](/docs/volumes). This means your themes, plugins, and uploaded media will not be lost on restarts, and can be shared between containers, supporting scaling.
 
-## Deploy the App
-
-```
-$ convox deploy
-```
-
 ## Attach the Database to the App
 
 The database creation that you kicked off above will take 10-15 minutes to complete. You can check status with:
@@ -65,12 +59,12 @@ Reference the URL output to set the necessary database environment variables on 
 $ convox env set WORDPRESS_DB_USER=app WORDPRESS_DB_NAME=app \
 WORDPRESS_DB_HOST=convox-dev-wordpress-db.cbm4183bzjrr.us-east-1.rds.amazonaws.com:3306 \
 WORDPRESS_DB_PASSWORD=EXWKHJKDZTBQIPGUMEKGSNTRYGAYAC
+```
 
-Updating environment... OK
-To deploy these changes run `convox releases promote RJTBVWWIKDE`
+## Deploy the App
 
-$ convox releases promote RJTBVWWIKDE
-Promoting RJTBVWWIKDE... UPDATING
+```
+$ convox deploy
 ```
 
 ## Run the WordPress Web Installer


### PR DESCRIPTION
Because of the move to `AWS::ECS::Service` these directions as written will no longer work. If you try to deploy the app before setting up the database, the service will never stabilize and the deployment will eventually roll back.

This PR changes the order of the steps to set the DB env vars first, so that when you deploy the app for the first time it will start.

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack

