### PR TITLE
Guide section that uses convox/guide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_guide"]
+	path = _guide
+	url = https://github.com/convox/guide.git

--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,9 @@ collections:
     title: Help
     output: true
     permalink: /docs/:name/
+  guide:
+    title: The Convox Guide 0.5
+    output: true
 
 defaults:
   - scope:
@@ -86,3 +89,8 @@ defaults:
       path: team
     values:
       layout: team
+  - scope:
+      path: guide
+    values:
+      layout: guide
+

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -32,6 +32,9 @@
         <a href="/docs">DOCS</a>
       </li>
       <li>
+        <a href="/guide">GUIDE</a>
+      </li>
+      <li>
         <a href="/jobs">JOBS</a>
       </li>
       <li>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,7 +16,7 @@ layout: base
         </button>
         <ul class="dropdown-menu docs-index">
           {% for collection in site.collections %}
-            {% if collection.label != "posts" %}
+            {% if (collection.label != "posts") && (collection.label != "guide") %}
               <li class="dropdown-header">{{ collection.title }}</li>
               {% assign pages = collection.docs | sort: 'order' %}
               {% for page in pages %}
@@ -33,7 +33,7 @@ layout: base
 <div class="container subnav-content docs" role="main">
   <section id="toc" class="col-md-3 col-lg-3 visible-md-block visible-lg-block">
     {% for collection in site.collections %}
-      {% if collection.label != "posts" %}
+      {% if (collection.label != "posts") && (collection.label != "guide") %}
         <div class="collection">
           <h3>{{ collection.title }}</h3>
           <ul>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,7 +16,7 @@ layout: base
         </button>
         <ul class="dropdown-menu docs-index">
           {% for collection in site.collections %}
-            {% if (collection.label != "posts") && (collection.label != "guide") %}
+            {% if (collection.label != "posts") and (collection.label != "guide") %}
               <li class="dropdown-header">{{ collection.title }}</li>
               {% assign pages = collection.docs | sort: 'order' %}
               {% for page in pages %}
@@ -33,7 +33,7 @@ layout: base
 <div class="container subnav-content docs" role="main">
   <section id="toc" class="col-md-3 col-lg-3 visible-md-block visible-lg-block">
     {% for collection in site.collections %}
-      {% if (collection.label != "posts") && (collection.label != "guide") %}
+      {% if (collection.label != "posts") and (collection.label != "guide") %}
         <div class="collection">
           <h3>{{ collection.title }}</h3>
           <ul>

--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -1,0 +1,64 @@
+---
+layout: base
+---
+
+{% assign collection = site.collections | where:"label","guide" | first %}
+
+<header>
+  <div class="container"><h2>The Convox Guide</h2></div>
+
+  <ul>
+    <li class="pull-right visible-md-block visible-lg-block"><h2 id="version"></h2></li>
+    <li class="pull-right visible-xs-block visible-sm-block">
+      <div class="btn-group visible-xs-block visible-sm-block pull-right" id="toc-collapsed">
+        <button id="toc-toggle" type="button" class="btn btn-xs btn-default dropdown-toggle"
+          data-toggle="dropdown" aria-expanded="false" aria-haspopup="true">
+          <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu docs-index guide">
+          <li class="dropdown-header">{{ collection.title }}</li>
+          {% for d in collection.docs %}
+            <li><a href="{{ doc.url }}"><span>{{ d.title }}</span></a></li>
+          {% endfor %}
+        </ul>
+      </div>
+    </li>
+  </ul>
+</header>
+
+<div class="container subnav-content docs guide" role="main">
+  <section id="toc" class="col-md-3 col-lg-3 visible-md-block visible-lg-block">
+    <div class="collection">
+      <h3>{{ collection.title }}</h3>
+      <ul>
+        {% for d in collection.docs %}
+          {% if d.pending %}
+              <li class="pending {{ d.phase }}">{{ d.title }}</li>
+          {% else %}
+            {% if page.title == d.title %}
+              <li class="active {{ d.phase }}"><a href="{{ d.url }}">{{ d.title }}</a></li>
+            {% else %}
+              <li class="{{ d.phase }}"><a href="{{ d.url }}"><span>{{ d.title }}</span></a></li>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+  </section>
+
+  <section id="doc" class="col-md-9 col-sm-12 col-xs-12">
+    <h1 class="title">{{ page.title }}</h1>
+
+    <div class="content">
+      {{ content }}
+    </div>
+
+    <div class="feedback">
+      We happily welcome
+      <a target="_new" href="https://github.com/convox/site/issues/new?title={{ page.title | cgi_escape }}+Feedback">feedback</a>
+      or
+      <a href="https://github.com/convox/site/edit/master/{{page.path}}">suggested changes</a> to this document.
+    </div>
+  </section>
+</div>

--- a/assets/css/convox.css
+++ b/assets/css/convox.css
@@ -37,6 +37,11 @@ a,a:hover,a:focus,a:active,a.active {
   color: #18bc9c;
 }
 
+code.highlighter-rouge {
+  border: 1px solid #eee;
+  padding: 3px 4px;
+}
+
 h1,h2,h3,h4,h5,h6, {
   font-family: 'Lato', Helvetica, Arial, sans-serif;
   font-weight: 700;
@@ -1495,9 +1500,39 @@ pre span {
   margin: 0;
 }
 
+.docs #doc pre.file:before {
+  background: #ddd;
+  content: attr(title);
+  display: block;
+  margin: -20px -20px 20px;
+  padding: 10px 20px;
+}
+
+/* "a" for added line in diff */
+.docs #doc pre.file .diff-a {
+  color: green;
+}
+
+.docs #doc pre.file .diff-a:before {
+  content: "+ ";
+}
+
+/* "r" for removed line in diff */
+.docs #doc pre.file .diff-r {
+  color: red;
+}
+
+.docs #doc pre.file .diff-r:before {
+  content: "- ";
+}
+
+/* "u" for unchanged line in diff */
+.docs #doc pre.file .diff-u:before {
+  content: "  ";
+}
+
 .docs #doc pre {
   background: #eee;
-  border-left: 25px solid #ddd;
   border-radius: 4px;
   color: #666;
   font-family: 'Roboto Mono', Monaco, Consolas, monospace;
@@ -1513,6 +1548,29 @@ pre span {
 
 .docs pre span {
   color: #666;
+}
+
+.docs #doc pre.terminal {
+  background: #444;
+  color: #bbb;
+}
+
+.docs #doc pre.terminal .command {
+  color: #eee;
+}
+
+.docs #doc pre.terminal .command:before {
+  content: "$";
+  color: #ea9b23;
+  margin-right: 10px;
+}
+
+.docs #doc pre.terminal .pass {
+  color: green;
+}
+
+.docs #doc pre.terminal .service {
+  color: aqua;
 }
 
 @media (max-width: 768px) {
@@ -1911,4 +1969,13 @@ pre span {
   border-top: 1px #ccc solid;
   margin-top: 30px;
   padding-top: 20px;
+}
+
+/* Guide */
+
+.guide #toc li.build,
+.guide #toc li.run,
+.guide #toc li.develop,
+.guide #toc li.deploy {
+  margin-left: 10px;
 }


### PR DESCRIPTION
Guide copy has been extracted to https://github.com/convox/guide. Please direct content feedback to that repo.

This PR is for the pieces to import the guide content as a site collection:

* guide content submodule
* site CSS for guide

![screen shot 2016-10-07 at 5 54 51 pm](https://cloud.githubusercontent.com/assets/147410/19206466/394a1a2c-8cb7-11e6-8f84-5cbcb0b10239.png)

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
