### PR TITLE
remove aws cli password reset steps

### DIFF
--- a/_management/api-keys.md
+++ b/_management/api-keys.md
@@ -28,21 +28,4 @@ The Rack may be temporarily unavailable while the change takes effect.
 
 If you're accessing a single Rack directly, a secure API key was generated on `convox install` and saved in `~/.convox/auth`.
 
-If you lose this key, it can not be recovered, and a new key must be set through the AWS CloudFormation Management Console or by using the aws-cli:
-
-```bash
-# Update the stack Password Parameter to a new secret
-
-$ STACK_NAME=convox
-$ KEY=$(uuidgen)
-
-$ aws cloudformation update-stack --stack-name $STACK_NAME --use-previous-template --capabilities CAPABILITY_IAM --parameters ParameterKey=Password,ParameterValue=$KEY
-{
-    "StackId": "arn:aws:cloudformation:us-east-1:132866487567:stack/convox/826bdce0-b30a-11e5-89a2-500c2866f062"
-}
-
-# Log into the Rack API with the new secret
-
-$ HOSTNAME=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "Dashboard") | .OutputValue')
-$ convox login $HOSTNAME -p $KEY
-```
+If you lose this key, it can not be recovered, and a new key must be set through the AWS CloudFormation Management Console.

--- a/_management/api-keys.md
+++ b/_management/api-keys.md
@@ -26,6 +26,10 @@ The Rack may be temporarily unavailable while the change takes effect.
 
 ### Logging into a Rack Directly
 
-If you're accessing a single Rack directly, a secure API key was generated on `convox install` and saved in `~/.convox/auth`.
+If you're accessing a single Rack directly, a secure API key was generated on `convox install` and saved in `~/.convox/auth`. Use the hostname from `~/.convox/auth` to log into the Rack:
 
-If you lose this key, it can not be recovered, and a new key must be set through the AWS CloudFormation Management Console.
+```
+$ convox login <hostname>
+```
+
+If you lose the Rack key, it can not be recovered, and a new key must be set through the AWS CloudFormation Management Console.


### PR DESCRIPTION
Something about the AWS cli commands here causes rack parameters to get reverted, including the instance count and type parameters, which is dangerous. This PR removes those instructions until we can figure out how to safely reset the password via aws cli.

## Release Playbook
- [x] Rebase against master
- [x] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack

