### PR TITLE
Sticky guide sidebars

### DIFF
--- a/assets/css/convox.css
+++ b/assets/css/convox.css
@@ -1360,7 +1360,7 @@ pre span {
   color: #444;
   margin-bottom: 1.2em;
   font-size: 0.9em;
-  
+
 }
 
 .posts table tr {
@@ -1432,6 +1432,9 @@ pre span {
 }
 
 .docs #toc {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 60px;
   padding: 40px 40px 40px 15px;
   width: 25%;
 }


### PR DESCRIPTION
The guide's really rad — thanks! — and I thought it might be helpful to make the sidebar sticky, for those of us on really stupid browsers that support it, like Safari (I think Chrome still hides this behind a flag or something).

See:

![convox](https://cloud.githubusercontent.com/assets/2723/19504751/adb3c6c0-9571-11e6-9920-c0a8aa98b24e.gif)

(Haha, apparently this gif doesn't loop at all, sorry, too lazy to fix it.)

This comes from the department of stupid-shit-I-add-because-eventually-other-browsers-will-support-it-but-in-the-meantime-I-want-it-now. Case in point: I made the GitHub Issues sidebar sticky two years ago and I swear to god someone will notice it as soon as Chrome adds support and I'm not going to get any credit for it anymore and these are the things that keep me up at night.

/cc @nzoschke and co