### PR TITLE
[WIP] Algolia Docs Search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM convox/jekyll
 
+# copy only the files needed for bundle install
+COPY Gemfile      /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+
 COPY _config/nginx.conf /etc/nginx/server.d/convox.conf
 
 COPY . /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+
+group :jekyll_plugins do
+  gem 'algoliasearch-jekyll', '~> 0.8.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,21 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    algoliasearch (1.11.0)
+      httpclient (~> 2.8.2)
+      json (>= 1.5.1)
+    algoliasearch-jekyll (0.8.0)
+      algoliasearch (~> 1.4)
+      appraisal (~> 2.1.0)
+      awesome_print (~> 1.6)
+      json (~> 1.8)
+      nokogiri (~> 1.6)
+      verbal_expressions (~> 0.1.5)
+    appraisal (2.1.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+    awesome_print (1.7.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -53,6 +68,7 @@ GEM
     html-pipeline (2.3.0)
       activesupport (>= 2, < 5)
       nokogiri (>= 1.4)
+    httpclient (2.8.2.4)
     i18n (0.7.0)
     jekyll (3.0.3)
       colorator (~> 0.1)
@@ -105,6 +121,7 @@ GEM
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
     public_suffix (1.5.3)
+    rake (11.1.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -117,14 +134,20 @@ GEM
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
     terminal-table (1.5.2)
+    thor (0.19.1)
     thread_safe (0.3.5)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    verbal_expressions (0.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  algoliasearch-jekyll (~> 0.8.0)
   github-pages
+
+BUNDLED WITH
+   1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,12 @@
 url: https://convox.com
 
+gems:
+  - algoliasearch-jekyll
+
+algolia:
+  application_id: 3J8PEXNWZD
+  index_name: site
+
 excerpt_separator: <!--more-->
 
 kramdown:

--- a/_includes/algolia.html
+++ b/_includes/algolia.html
@@ -1,0 +1,57 @@
+{% raw  %}
+<script type="text/html" id="hit-template">
+  <div class="hit">
+    <div class="hit-content">
+      <h3 class="hit-title">{{{title}}}</h3>
+      <p class="hit-text">{{{text}}}</p>
+    </div>
+  </div>
+</script>
+
+<script type="text/html" id="no-results-template">
+  <div id="no-results-message">
+    <p>We didn't find any results for the search <em>"{{query}}"</em>.</p>
+    <a href="." class="clear-all">Clear search</a>
+  </div>
+</script>
+{% endraw  %}
+
+<script type="text/javascript">
+  var search = instantsearch({
+    // Replace with your own values
+    appId: '3J8PEXNWZD',
+    apiKey: 'e9a5de9437dcbb1849e5c23eeb58be29', // search only API key, no ADMIN key
+    indexName: 'site',
+    urlSync: true
+  });
+
+  search.addWidget(
+    instantsearch.widgets.searchBox({
+      container: '#search-input',
+      placeholder: 'Search documentation'
+    })
+  );
+
+  search.addWidget(
+    instantsearch.widgets.hits({
+      container: '#hits',
+      hitsPerPage: 10,
+      templates: {
+        item: getTemplate('hit'),
+        empty: getTemplate('no-results')
+      }
+    })
+  );
+
+  search.addWidget(
+    instantsearch.widgets.stats({
+      container: '#stats'
+    })
+  );
+
+  search.start();
+
+  function getTemplate(templateName) {
+    return document.getElementById(templateName + '-template').innerHTML;
+  }
+</script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -28,6 +28,10 @@
     <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css">
+    <script src="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.js"></script>
+    <script src="app.js"></script>
   </head>
 
   <body>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,7 +3,12 @@ layout: base
 ---
 
 <header>
-  <div class="container"><h2>Convox Documentation</h2></div>
+  <div class="container">
+    <h2>Convox Documentation</h2>
+
+    <div id="search-input"></div>
+    <div id="search-input-icon"></div>
+  </div>
 
   <ul>
     <li class="pull-right visible-md-block visible-lg-block"><h2 id="version"></h2></li>
@@ -52,6 +57,14 @@ layout: base
   </section>
 
   <section id="doc" class="col-md-9 col-sm-12 col-xs-12">
+    <div>
+      <div id="right-column">
+      <div id="sort-by-wrapper"><span id="sort-by"></span></div>
+      <div id="stats"></div>
+      <div id="hits"></div>
+      <div id="pagination"></div>
+    </div>
+
     <h1 class="title">{{ page.title }}</h1>
 
     <div class="content">
@@ -66,3 +79,5 @@ layout: base
     </div>
   </section>
 </div>
+
+{% include algolia.html %}


### PR DESCRIPTION
An experiment with Algolia, which is free as long as you include their logo by the search stuff.

This adds the Jekyll plugin and a very quick spike at the instantsearch JS stuff.

I manually did the first `ALGOLIA_API_KEY='your_write_api_key' jekyll algolia push`. This could be automated with Convox Workflows ™.

I'm surprised how manual building the search UI is. The pieces make sense  but it'll require more HTML/CSS/JS wizardry to make it awesome.
## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
