### PR TITLE
Contact Form

### DIFF
--- a/_includes/blog-extras.html
+++ b/_includes/blog-extras.html
@@ -1,0 +1,17 @@
+<section class="extras">
+  <section class="what-is-convox">
+    <h3>What is Convox?</h3>
+    <p>Convox is an open-source framework for your cloud infrastructure.</p>
+  </section>
+
+  <section class="newsletter">
+    <h3>Keep up</h3>
+    <p>Convox is evolving quickly. Subscribe to our newsletter to stay on top of the latest developments.</p>
+    {% include mailchimp.html %}
+  </section>
+
+  <section class="console">
+    <h3>Dive in</h3>
+    <p>Ready to get started? <a href="https://console.convox.com/grid/signup">Sign up</a> for a Convox account now.</p>
+  </section>
+</section>

--- a/_includes/mailchimp.html
+++ b/_includes/mailchimp.html
@@ -1,0 +1,50 @@
+<!--mailchimp-->
+<div id="mc_embed_signup">
+  <form action="//convox.us10.list-manage.com/subscribe/post-json?u=55a0526a0c4fd5e0010c9bae3&amp;id=69fa821fe6&c=?" method="get" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+      <div id="mce-responses" class="clear">
+        <div class="response" id="mce-error-response" style="display:none"></div>
+        <div class="response" id="mce-success-response" style="display:none"></div>
+      </div><!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+      <div style="position: absolute; left: -5000px;" aria-hidden="true">
+        <input type="text" name="b_55a0526a0c4fd5e0010c9bae3_69fa821fe6" tabindex="-1" value="">
+      </div>
+
+      <input placeholder="name@example.com" type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+      <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
+    </div>
+  </form>
+</div>
+
+<script>
+  var $form = $("#mc-embedded-subscribe-form");
+
+  $form.find('input[type="submit"]').bind('click', function (e) {
+    if (e) e.preventDefault();
+
+    $.ajax({
+        type: $form.attr('method'),
+        url: $form.attr('action'),
+        data: $form.serialize(),
+        cache       : false,
+        dataType    : 'json',
+        contentType: "application/json; charset=utf-8",
+        error       : function(err) { alert("Could not connect to the registration server. Please try again later."); },
+        success     : function(data) {
+          if (data.result != "success") {
+            // strip off beginning of '0 - This email address looks fake or invalid. Please enter a real email address.'
+            var msg = data.msg.replace(/^[0-9]+ - /, "")
+            $("#mce-error-response").html(msg).show()
+          } else {
+            var email = $form.find('[name=EMAIL]').val();
+
+            analytics.identify({ email: email });
+            analytics.track("Subscription Created", { email: email });
+            analytics.page("/subscription_created");
+
+            $("#mc_embed_signup").html('<p>Thank you! Please check your inbox to confirm.</p>')
+          }
+        }
+    });
+  });
+</script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -38,19 +38,6 @@
     {{ content }}
 
     <footer class="text-left">
-      <div class="footer-middle">
-        <div class="container">
-          <div class="row">
-            <a id="join_slack" href="https://invite.convox.com" class="cta btnshadow green_button">Join&nbsp;Slack</a>
-            <span class="short-desc-r c-d-green">Chat with the Convox Team and community</span>
-          </div>
-          <div class="row last">
-            <a id="subscribe" href="https://t.co/r4Tta2jk0w" class="cta btnshadow orange_button">Subscribe</a>
-            <span class="short-desc-r c-orange">Receive occasional product updates and news</span>
-          </div>
-        </div>
-      </div>
-
       <div class="footer-bottom">
         <div class="container">
           <div class="row">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,73 +5,8 @@ layout: blog
 <main class="blog">
   <section class="content with-extras">
     {% include post.html post=page %}
-
-    <section class="extras">
-      <section class="what-is-convox">
-        <h3>What is Convox?</h3>
-        <p>Convox is an open-source framework for your cloud infrastructure.</p>
-      </section>
-
-      <section class="newsletter">
-        <h3>Keep up</h3>
-        <p>Convox is evolving quickly. Subscribe to our newsletter to stay on top of the latest developments.</p>
-
-        <div id="mc_embed_signup">
-          <form action="//convox.us10.list-manage.com/subscribe/post-json?u=55a0526a0c4fd5e0010c9bae3&amp;id=69fa821fe6&c=?" method="get" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <div id="mc_embed_signup_scroll">
-              <div id="mce-responses" class="clear">
-                <div class="response" id="mce-error-response" style="display:none"></div>
-                <div class="response" id="mce-success-response" style="display:none"></div>
-              </div><!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-              <div style="position: absolute; left: -5000px;" aria-hidden="true">
-                <input type="text" name="b_55a0526a0c4fd5e0010c9bae3_69fa821fe6" tabindex="-1" value="">
-              </div>
-
-              <input placeholder="name@example.com" type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-              <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
-            </div>
-          </form>
-        </div>
-      </section>
-
-      <section class="console">
-        <h3>Dive in</h3>
-        <p>Ready to get started? <a href="https://console.convox.com/grid/signup">Sign up</a> for a Convox account now.</p>
-      </section>
-    </section>
+    {% include blog-extras.html %}
   </section>
 </main>
 
-
-<script>
-  var $form = $("#mc-embedded-subscribe-form");
-
-  $form.find('input[type="submit"]').bind('click', function (e) {
-    if (e) e.preventDefault();
-
-    $.ajax({
-        type: $form.attr('method'),
-        url: $form.attr('action'),
-        data: $form.serialize(),
-        cache       : false,
-        dataType    : 'json',
-        contentType: "application/json; charset=utf-8",
-        error       : function(err) { alert("Could not connect to the registration server. Please try again later."); },
-        success     : function(data) {
-          if (data.result != "success") {
-            // strip off beginning of '0 - This email address looks fake or invalid. Please enter a real email address.'
-            var msg = data.msg.replace(/^[0-9]+ - /, "")
-            $("#mce-error-response").html(msg).show()
-          } else {
-            var email = $form.find('[name=EMAIL]').val();
-
-            analytics.identify({ email: email });
-            analytics.track("Subscription Created", { email: email });
-            analytics.page("/subscription_created");
-
-            $("#mc_embed_signup").html('<p>Thank you! Please check your inbox to confirm.</p>')
-          }
-        }
-    });
-  });
-</script>
+{% include mailchimp.html %}

--- a/assets/css/convox.css
+++ b/assets/css/convox.css
@@ -10,7 +10,7 @@ body {
   font-family: 'Lato', Helvetica, Arial, sans-serif;
   font-size: 16px;
   font-weight: 400;
-  margin-bottom: 267px;
+  /*margin-bottom: 267px;*/
 }
 
 @font-face {
@@ -226,7 +226,11 @@ header .intro-text .name-desc {
   text-decoration: none;
 }
 
-.services {
+.contact .slack h2 {
+  margin-top: 50px;
+}
+
+.services, .contact {
   background-color: #f6f6f6;
   border-bottom: 1px solid #dddddd;
   padding-top: 35px;
@@ -943,9 +947,7 @@ h3 {
 }
 
 footer {
-  bottom: 0;
   color: #fff;
-  height: 267px;
   position: absolute;
   width: 100%;
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,71 +15,9 @@ layout: blog
         <a href="/blog/rss.xml"><img src="/assets/images/static/rss-icon.png"></a>
       </div>
     </section>
-    <section class="extras">
-      <section class="what-is-convox">
-        <h3>What is Convox?</h3>
-        <p>Convox is an open-source framework for your cloud infrastructure.</p>
-      </section>
 
-      <section class="newsletter">
-        <h3>Keep up</h3>
-        <p>Convox is evolving quickly. Subscribe to our newsletter to stay on top of the latest developments.</p>
-
-        <div id="mc_embed_signup">
-          <form action="//convox.us10.list-manage.com/subscribe/post-json?u=55a0526a0c4fd5e0010c9bae3&amp;id=69fa821fe6&c=?" method="get" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <div id="mc_embed_signup_scroll">
-              <div id="mce-responses" class="clear">
-                <div class="response" id="mce-error-response" style="display:none"></div>
-                <div class="response" id="mce-success-response" style="display:none"></div>
-              </div><!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-              <div style="position: absolute; left: -5000px;" aria-hidden="true">
-                <input type="text" name="b_55a0526a0c4fd5e0010c9bae3_69fa821fe6" tabindex="-1" value="">
-              </div>
-
-              <input placeholder="name@example.com" type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-              <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
-            </div>
-          </form>
-        </div>
-      </section>
-
-      <section class="console">
-        <h3>Dive in</h3>
-        <p>Ready to get started? <a href="https://console.convox.com/grid/signup">Sign up</a> for a Convox account now.</p>
-      </section>
-    </section>
+    {% include blog-extras.html %}
   </section>
 </main>
 
-<script>
-  var $form = $("#mc-embedded-subscribe-form");
-
-  $form.find('input[type="submit"]').bind('click', function (e) {
-    if (e) e.preventDefault();
-
-    $.ajax({
-        type: $form.attr('method'),
-        url: $form.attr('action'),
-        data: $form.serialize(),
-        cache       : false,
-        dataType    : 'json',
-        contentType: "application/json; charset=utf-8",
-        error       : function(err) { alert("Could not connect to the registration server. Please try again later."); },
-        success     : function(data) {
-          if (data.result != "success") {
-            // strip off beginning of '0 - This email address looks fake or invalid. Please enter a real email address.'
-            var msg = data.msg.replace(/^[0-9]+ - /, "")
-            $("#mce-error-response").html(msg).show()
-          } else {
-            var email = $form.find('[name=EMAIL]').val();
-
-            analytics.identify({ email: email });
-            analytics.track("Subscription Created", { email: email });
-            analytics.page("/subscription_created");
-
-            $("#mc_embed_signup").html('<p>Thank you! Please check your inbox to confirm.</p>')
-          }
-        }
-    });
-  });
-</script>
+{% include mailchimp.html %}

--- a/index.html
+++ b/index.html
@@ -250,3 +250,26 @@ web: "POST /users HTTP/1.1" 303 - 0.0049
   </div>
 </section>
 
+<!-- Contact Section -->
+<section class="contact">
+  <div class="container">
+
+    <div class="col-lg-12 text-center">
+      <h2>Keep up</h2>
+      <p>Convox is evolving quickly. Subscribe to our newsletter to stay on top of the latest developments.</p>
+    </div>
+
+    <div class="col-md-offset-4 col-md-4 col-xs-12">
+      {% include mailchimp.html %}
+    </div>
+
+    <div class="col-lg-12 text-center slack">
+      <h2>Chat with the Convox team and community</h2>
+      <p>Convox is very active. Join our Slack to ask questions and get answers.</p>
+    </div>
+
+    <div class="col-md-offset-4 col-md-4 col-xs-12 text-center">
+      <script async defer src="https://invite.convox.com/slackin.js?large"></script>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
One step towards removing aqua buttons. Drop the Slack and Subscribe buttons that link off to another property. Replace with inline signup forms.

<img width="1022" alt="screen shot 2016-10-28 at 2 47 06 pm" src="https://cloud.githubusercontent.com/assets/147410/19823425/709f014c-9d1d-11e6-9ea7-bc5b4db134c1.png">

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
