### PR TITLE
CLI Link

### DIFF
--- a/_config/nginx.conf
+++ b/_config/nginx.conf
@@ -5,6 +5,14 @@ location /docs/ {
   error_page 404 /docs/404/index.html;
 }
 
+location /install/osx.zip {
+    proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-darwin-amd64.zip;
+}
+
+location /install/linux.zip {
+    proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-linux-amd64.zip;
+}
+
 #####
 # redirects for old, broken links observed with:
 # $ convox logs --app site-production --filter='GET 404' --since=48h --follow=false | cut -d" " -f9 | sort -u

--- a/_config/nginx.conf
+++ b/_config/nginx.conf
@@ -13,6 +13,8 @@ location /install/linux.zip {
     proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-linux-amd64.zip;
 }
 
+location /signup { return 301 https://console.convox.com/grid/signup ; }
+
 #####
 # redirects for old, broken links observed with:
 # $ convox logs --app site-production --filter='GET 404' --since=48h --follow=false | cut -d" " -f9 | sort -u

--- a/_guide/01-introduction.md
+++ b/_guide/01-introduction.md
@@ -7,7 +7,9 @@ Welcome to the Convox Guide, a set of step-by-step instructions for developing, 
 
 This guide is written for app developers who are ready to learn modern practices that make an app simple to develop on a laptop and effortless to manage in the cloud.
 
-We begin with the Convox Command Line Interface, which you should install on your laptop to verify and develop your app.
+First, <a href="https://console.convox.com/grid/signup" target="_blank">sign up for Convox</a>. Later in the guide you will use the web console to set up your AWS environment.
+
+Next, install the Convox Command Line Interface. The `convox` tool is all you need for your development environment.
 
 ## OS X
 
@@ -23,7 +25,12 @@ $ curl -Ls https://convox.com/install/linux.zip > /tmp/convox.zip
 $ unzip /tmp/convox.zip -d /usr/local/bin
 ```
 
-Later chapters of the guide reference [Convox Console](https://console.convox.com/grid/signup). [Sign up](https://console.convox.com/grid/signup) to automate your apps.
+Finally, register the CLI with Convox.
+
+```
+$ convox login
+Password: <Your Console API key>
+```
 
 # Preface
 

--- a/_guide/01-introduction.md
+++ b/_guide/01-introduction.md
@@ -7,7 +7,21 @@ Welcome to the Convox Guide, a set of step-by-step instructions for developing, 
 
 This guide is written for app developers who are ready to learn modern practices that make an app simple to develop on a laptop and effortless to manage in the cloud.
 
-We begin with the [Convox Command Line Interface](https://dl.equinox.io/convox/convox/stable), which you should install on your laptop to verify and develop your app.
+We begin with the Convox Command Line Interface, which you should install on your laptop to verify and develop your app.
+
+## OS X
+
+```
+$ curl -Ls https://convox.com/install/osx.zip > /tmp/convox.zip
+$ unzip /tmp/convox.zip -d /usr/local/bin
+```
+
+## Linux
+
+```
+$ curl -Ls https://convox.com/install/linux.zip > /tmp/convox.zip
+$ unzip /tmp/convox.zip -d /usr/local/bin
+```
 
 Later chapters of the guide reference [Convox Console](https://console.convox.com/grid/signup). [Sign up](https://console.convox.com/grid/signup) to automate your apps.
 

--- a/_guide/02-overview.md
+++ b/_guide/02-overview.md
@@ -25,11 +25,25 @@ This will save you endless frustrations in production.
 
 ## Setup
 
-You can't work on the Build phase until your computer is set up with the pre-requisites.
+You can't work on the Build phase until your computer is set up with the tools.
 
-First [Download and install the Convox CLI](https://dl.equinox.io/convox/convox/stable).
+If you haven't already, install the Convox Command Line Interface:
 
-Next run `convox doctor` to run the first checklist:
+## OS X
+
+```
+$ curl -Ls https://convox.com/install/osx.zip > /tmp/convox.zip
+$ unzip /tmp/convox.zip -d /usr/local/bin
+```
+
+## Linux
+
+```
+$ curl -Ls https://convox.com/install/linux.zip > /tmp/convox.zip
+$ unzip /tmp/convox.zip -d /usr/local/bin
+```
+
+Now run `convox doctor` to run the first checklist:
 
 ```
 $ convox doctor

--- a/_introduction/getting-started.md
+++ b/_introduction/getting-started.md
@@ -33,12 +33,12 @@ You can [download the CLI package](https://dl.equinox.io/convox/convox/stable) o
 
 #### OS X
 
-    $ curl -Ls https://install.convox.com/osx.zip > /tmp/convox.zip
+    $ curl -Ls https://convox.com/install/osx.zip > /tmp/convox.zip
     $ unzip /tmp/convox.zip -d /usr/local/bin
     
 #### Linux
 
-    $ curl -Ls https://install.convox.com/linux.zip > /tmp/convox.zip
+    $ curl -Ls https://convox.com/install/linux.zip > /tmp/convox.zip
     $ unzip /tmp/convox.zip -d /usr/local/bin
 
 ## Run an Application Locally

--- a/_introduction/getting-started.md
+++ b/_introduction/getting-started.md
@@ -29,7 +29,7 @@ We provide a `convox` command line tool that offers:
 
 along with numerous other utilities that make building, configuring, scaling and securing your apps easy.
 
-You can [download the CLI package](https://dl.equinox.io/convox/convox/stable) or install it via the command line:
+You can install it via the command line:
 
 #### OS X
 


### PR DESCRIPTION
I've been getting feedback that linking to the equinox installer page and .zip package is confusing.

This unifies on installing the CLI from `https://convox.com/install/{osx,linux}.zip` with curl and unzip.

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
