### PR TITLE
Adding Algolia DocSearch

### DIFF
--- a/_includes/algolia.html
+++ b/_includes/algolia.html
@@ -6,30 +6,14 @@
     </svg>
 </div>
 
-<!-- Include AlgoliaSearch JS Client and autocomplete.js library -->
-<script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
-<script src="https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>
+<link href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
 
-<!-- Initialize autocomplete menu -->
 <script>
-var client = algoliasearch("2VBKDVKUPC", "dcc7c629858d6e95092e558af5581cbf");
-var index = client.initIndex('convox');
-
-
-//initialize autocomplete on search input (ID selector must match)
-autocomplete('#aa-search-input',
-{ hint: false }, {
-    source: autocomplete.sources.hits(index, {hitsPerPage: 5}),
-    //value to be displayed in input control after user's suggestion selection
-    displayKey: 'title',
-    //hash of templates used when rendering dataset
-    templates: {
-        //'suggestion' templating function used to render a single suggestion
-        suggestion: function(suggestion) {
-          return '<span>' +
-            suggestion._highlightResult.title.value + '</span><span>' +
-            suggestion._highlightResult.text.value + '</span>';
-        }
-    }
+docsearch({
+  apiKey: '394a458b0a2b19ad49668838eff2ea61',
+  indexName: 'convox',
+  inputSelector: '#aa-search-input'
 });
 </script>
+

--- a/assets/css/algolia.css
+++ b/assets/css/algolia.css
@@ -1,3 +1,6 @@
+.aa-dropdown-menu {
+  text-transform: none;
+}
 @import url('https://fonts.googleapis.com/css?family=Merriweather:400,400i,700');
 .aa-input-container {
   display: inline-block;
@@ -39,80 +42,3 @@
   fill: #EA9B00;
   pointer-events: none; }
 
-.aa-hint {
-  color: red; }
-
-.aa-dropdown-menu {
-    width: 600px;
-    background-color: #fff;
-    border: 2px solid rgba(228, 228, 228, 0.6);
-    border-top-width: 0;
-    font-family: "Merriweather", sans-serif;
-    font-style: italic;
-    font-weight: 400;
-    margin-top: 10px;
-    box-shadow: 4px 4px 0 rgba(241, 241, 241, 0.35);
-    font-size: 11px;
-    border-radius: 4px;
-    box-sizing: border-box; }
-
-  .aa-dropdown-menu > div {
-    display: inline-block;
-    width: 100%;
-    vertical-align: top; }
-
-.aa-suggestion {
-  padding: 6px 12px;
-  cursor: crosshair;
-  -webkit-transition: .2s;
-  transition: .2s;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center; }
-
-  .aa-suggestion:hover, .aa-suggestion.aa-cursor {
-    background-color: rgba(235, 155, 0, 0.1122); }
-
-  .aa-suggestion > div {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-pack: justify;
-        -ms-flex-pack: justify;
-            justify-content: space-around;
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    width: 100%; }
-
-.aa-suggestion span {
-    color: #1777BB; 
-    text-transform: none; }
-
-.aa-suggestion span:first-child, .aa-suggestion span:last-child {
-    color: #888;
-    min-width: 200px;}
-
-    .aa-suggestion span:first-child {
-      font-family: "Lato", "Helvetica", "Arial", san-serif;
-text-transform: uppercase;
-      font-weight: 700;
-      font-style: normal;
-    color: #1777BB; }
-
-.aa-suggestion span:first-child em, .aa-suggestion span:last-child em {
-  font-weight: 700;
-  font-style: normal;
-  background-color: rgba(58, 150, 207, 0.1);
-  padding: 2px 0 2px 2px; }
-
-
-
-.aa-empty {
-  padding: 6px 12px; }


### PR DESCRIPTION
Here is a PR to add Algolia DocSearch to the website, following your support ticket.

![2016-11-21_21h53m06](https://cloud.githubusercontent.com/assets/283419/20500242/f32f0646-b034-11e6-851e-e3df469d53f1.gif)

DocSearch is way easier to use than the Jekyll plugin. We actually have a cron that will crawl your website every 24 hours, read the HTML markup, and index it into Algolia. It comes with its own JavaScript library (`docsearch`) that will bind a specific input to display results on each keystrokes. And best of all, it's free and you don't need an Algolia account to use it.

This means that, unfortunatly, all the work you've put into integrating the Jekyll plugin was not needed here. Advantages of DocSearch over the Jekyll plugin is that it's easier to install and maintain, and really tailored for search in technical documentation. The downside is that it's a crawler running every 24h, so if you push a new version of your website you'll have to wait (at most) 24h to get it correctly indexed.

Let me know if this works for you. I think DocSearch is better suited for you, but if for whatever reason you'd rather continue with the Jekyll plugin, I can submit another PR with the relevant JS and CSS code, but it will be more complex. 
