### PR TITLE
remove link to automation page

### DIFF
--- a/_guide/19-resources.md
+++ b/_guide/19-resources.md
@@ -99,5 +99,3 @@ For more information on resources, see:
 * [The Twelve-Factor App: Backing services](https://12factor.net/backing-services){:target="_blank"}
 
 {% include definitions/changes/service-to-resource.md %}
-
-Up next: [Automation](/guide/automate/)!


### PR DESCRIPTION
Looks like this page doesn't exist anymore. Should the link be removed or updated to something else?

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack

