### PR TITLE
Refactor to make cleanup function obsolet. Add correct keycode

### DIFF
--- a/assets/js/focus-search-box.js
+++ b/assets/js/focus-search-box.js
@@ -1,36 +1,34 @@
-function inputFocus(){
-    'use strict';
-    // Focus search field when user types a slash
-    var keycode = (event.keyCode ? event.keyCode : event.which);
+// Search Box Event Handler
+
+$(document).keydown(function (e) {
     var f = document.getElementById("aa-search-input");
-    if(keycode == '191' || keycode == '47' || keycode == '45'){
-        f.focus();
+    switch (e.which) {
+        // Focus search field when user types defined keys
+        case 47:
+        case 191:
+        case 189:
+            if (f !== document.activeElement) {
+                event.preventDefault();
+                f.focus();
+            } else {
+                // Close search box if pressed again and field is empty
+                if (f.value == '') {
+                    f.blur();
+                }
+            }
+            break;
+        // Remove search field focus when user presses <ESC>
+        case 27:
+            f.blur();
+            break;
     }
- }
-
- function clearSearch() {
-    // Remove the / from the search field
-    var f = document.getElementById("aa-search-input");
-    if(f.value == "/"){
-        f.value = "";
-        f.focus();
-    }
-
-    // Remove search field focus when user presses <ESC>
-    var keycode = (event.keyCode ? event.keyCode : event.which);
-    if(keycode == '27') {
-        $(document.activeElement).blur();
-    }
- }
-
-window.onkeydown = inputFocus;
-window.onkeyup = clearSearch;
+});
 
 // Logging function that accounts for browsers that don't have window.console
-function log(){
-  log.history = log.history || [];
-  log.history.push(arguments);
-  if(this.console){
-    console.log( Array.prototype.slice.call(arguments)[0] );
-  }
+function log() {
+    log.history = log.history || [];
+    log.history.push(arguments);
+    if (this.console) {
+        console.log(Array.prototype.slice.call(arguments)[0]);
+    }
 }


### PR DESCRIPTION
- Add correct Keycode for QWERTZ  
- Prevent default behavior for keydown
- Remove clean up function
- Add toggle functionality if search field is still empty
- Clean up code
- Refactor code to switch statement

@soulshake I changed some stuff. Hope you like it. Somehow I gave you the wrong keycode (my bad). Cleanup was not working for that keycode, but I think it's much simpler to prevent the default key behavior in the first place so no clean up is needed at all. 
I switched the function to JQuery keydown listener. I think thats more native. I changed the code to a switch statement because it should be faster and is more readable in my personal opinion. Additional keycodes can be added easily.   

Please get rid of the toggle functionality, if you don't like it. I thought it'll be nice to have that functionality as long as the search field is still empty, so you don't have to reach for ESC to deactivate it again. 

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
