### PR TITLE
Restore link to api manifest.yml on rack repo

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -38,7 +38,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = '/api/manifest.yml'
+        url = "https://raw.githubusercontent.com/convox/rack/master/api/manifest.yml";
       }
 
       hljs.configure({


### PR DESCRIPTION
This is the way it was before; pointing to the site/api/manifest.yml was a temporary measure.

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
