### PR TITLE
Revert "Restore link to api manifest.yml on rack repo"

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -38,7 +38,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "https://raw.githubusercontent.com/convox/rack/master/api/manifest.yml";
+        url = '/api/manifest.yml'
       }
 
       hljs.configure({


### PR DESCRIPTION
This reverts commit 7e237d11de6e5eabfa386f902376cd526f3e8f1b.

Will revert this revert once https://github.com/convox/rack/pull/1922 is in production.

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
