### PR TITLE
Update day of week schedule expression to match AWS

### DIFF
--- a/_deployment/scheduled-tasks.md
+++ b/_deployment/scheduled-tasks.md
@@ -34,7 +34,7 @@ Cron expressions use the following format. All times are UTC.
 |  .------------- hour (0 - 23)
 |  |  .---------- day-of-month (1 - 31)
 |  |  |  .------- month (1 - 12) OR JAN,FEB,MAR,APR ...
-|  |  |  |  .---- day-of-week (0 - 6) (Sunday=0 or 7) OR SUN,MON,TUE,WED,THU,FRI,SAT
+|  |  |  |  .---- day-of-week (1 - 7) OR SUN,MON,TUE,WED,THU,FRI,SAT
 |  |  |  |  |
 *  *  *  *  *
 ```


### PR DESCRIPTION
Update day of week schedule expression to match AWS:

http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html

## Release Playbook
- [x] Rebase against master
- [x] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
