### PR TITLE
Update BUNDLE_WITHOUT groups in Dockerfile doc

### DIFF
--- a/_reference/dockerfile.md
+++ b/_reference/dockerfile.md
@@ -28,7 +28,7 @@ Warning: It is not recommended to use build-time variables for passing secrets. 
 You can declare a build argument in the `Dockerfile`, with either a default value or an empty one:
 
 ```
-ARG BUNDLE_WITHOUT="development test"
+ARG BUNDLE_WITHOUT="development:test"
 ARG RAILS_ENV
 ```
 
@@ -38,14 +38,14 @@ You can then send a value to the `ARG` during the local build by defining that v
 
 ```
 $ cat .env
-BUNDLE_WITHOUT="development test"
+BUNDLE_WITHOUT="none"
 ```
 
 or by setting it in your host environment, like this:
 
 ```
-$ BUNDLE_WITHOUT="development test" convox start
-build    │ running: docker build --build-arg BUNDLE_WITHOUT="development test" -f /home/aj/git/convox/convox-examples/rails/Dockerfile -t rails/web /home/aj/git/convox/convox-examples/rails
+$ BUNDLE_WITHOUT="none" convox start
+build    │ running: docker build --build-arg BUNDLE_WITHOUT="none" -f /home/aj/git/convox/convox-examples/rails/Dockerfile -t rails/web /home/aj/git/convox/convox-examples/rails
 [...]
 ```
 
@@ -56,7 +56,7 @@ Note: Build arguments defined in `.env` supersede values in the host environment
 You can send a value (or set an empty value, as below) to be applied during remote builds on your Rack by setting it with `convox env`:
 
 ```
-$ convox env set BUNDLE_WITHOUT= --promote
+$ convox env set BUNDLE_WITHOUT=none --promote
 $ convox deploy
 ```
 


### PR DESCRIPTION
In the existing examples on https://convox.com/docs/dockerfile, we encouraged excluding the development and test Gemfile groups during local builds, which is actually when they would be most relevant. Instead, we want to exclude them (via `BUNDLE_WITHOUT="development:test"`) in the Dockerfile so they apply to production by default, and then allow them locally with a `BUNDLE_WITHOUT=none`, which is a somewhat hacky way of saying "don't exclude any gem groups."

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
