### PR TITLE
Prevent fixed header from overlapping anchors

### DIFF
--- a/assets/css/convox.css
+++ b/assets/css/convox.css
@@ -2384,3 +2384,18 @@ img + em {
   padding: 15% 50px 25%;
   text-align: center;
 }
+
+
+/*
+ *
+ * Anchor offset for compatibility with fixed header
+ * http://stackoverflow.com/a/28824157
+ *
+ */
+
+:target:before {
+  content: "";
+  display: block;
+  height: 90px;
+  margin: -90px 0 0;
+}


### PR DESCRIPTION
Only tested in Chrome and Safari.

---

## Before
http://localhost/docs/overview/#the-convox-philosophy

<img width="839" alt="screen shot 2017-03-08 at 12 09 00 pm" src="https://cloud.githubusercontent.com/assets/218440/23714668/15e11410-03f8-11e7-8985-71393b5e41b7.png">

## After
http://localhost/docs/overview/#the-convox-philosophy

<img width="840" alt="screen shot 2017-03-08 at 12 08 08 pm" src="https://cloud.githubusercontent.com/assets/218440/23714672/18d42662-03f8-11e7-9826-f4b2dd5cf90a.png">


## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
