### PR TITLE
Replace /install/* proxy_pass with a 301 redirect

### DIFF
--- a/_config/nginx.conf
+++ b/_config/nginx.conf
@@ -5,14 +5,6 @@ location /docs/ {
   error_page 404 /docs/404/index.html;
 }
 
-location /install/osx.zip {
-    proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-darwin-amd64.zip;
-}
-
-location /install/linux.zip {
-    proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-linux-amd64.zip;
-}
-
 location /signup { return 301 https://console.convox.com/grid/signup ; }
 
 #####
@@ -86,3 +78,6 @@ location /docs/docs/troubleshooting-install                                 { re
 location /docs/docs/updating-convox                                         { return 301 https://$server_name/docs/installing-a-rack/ ; }
 
 location /privacy                                                           { return 301 https://$server_name/legal/privacy ; }
+location /install                                                           { return 301 https://$server_name/docs/installation/ ; }
+location /install/osx.zip                                                   { return 301 https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-darwin-amd64.zip ; }
+location /install/linux.zip                                                 { return 301 https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-linux-amd64.zip ; }


### PR DESCRIPTION
## TL;DR

We should either replace the `proxy_pass` entries with redirects (as proposed in this PR) or configure nginx to re-resolve them to avoid broken installer links when bin.equinox.io changes IPs.

## Details 

We have two `proxy_pass` entries in `_config/nginx.conf`:
```
-location /install/osx.zip   { proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-darwin-amd64.zip; }
 -location /install/linux.zip { proxy_pass https://bin.equinox.io/c/jewmwFCp7w9/convox-stable-linux-amd64.zip; }
```

nginx resolves proxy_pass targets at boot and doesn't re-resolve them unless configured to do so. This stale DNS situation was the underlying cause of the inaccessibility of `https://convox.com/install/osx.zip` and `https://convox.com/install/linux.zip` today, because the target `bin.equinox.io` changed IPs.

From the nginx logs:
```
`2017/03/12 22:09:52 [error] 11#11: *96148 upstream timed out (110: Connection timed out) while connecting to upstream, client: 127.0.0.1, server: convox.com, request: "HEAD /install/osx.zip HTTP/1.1", upstream: "https://54.225.115.107:443/c/jewmwFCp7w9/convox-stable-darwin-amd64.zip", host: "localhost:4001"`
```

From my host:

 ```$ host bin.equinox.io
bin.equinox.io is an alias for wakayama-8830.herokussl.com.
wakayama-8830.herokussl.com is an alias for elb074459-590231390.us-east-1.elb.amazonaws.com.
elb074459-590231390.us-east-1.elb.amazonaws.com has address 23.23.208.64
elb074459-590231390.us-east-1.elb.amazonaws.com has address 54.243.34.11
elb074459-590231390.us-east-1.elb.amazonaws.com has address 50.17.249.180
```

A simple `convox ps --rack convox/production --app site-production stop <pid>` on both site-production web processes resolved (heh) the issue.

---

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
