### PR TITLE
Add documentation about links

### DIFF
--- a/_reference/convox.yml.md
+++ b/_reference/convox.yml.md
@@ -93,6 +93,8 @@ services:
     image: ubuntu:16.04
     init: true
     port: 3000
+    links:
+      - api
     resources:
       - database
     scale:
@@ -204,6 +206,10 @@ Your rack must have the `Internal` param set to Yes to deploy internal services.
 ```shell
 $ convox rack params set Internal=Yes
 ```
+
+### links
+
+Define a link to another service. For more information about linking, read [this section](https://convox.com/docs/gen1/linking/) in the Generation 1 documentation.
 
 ### port
 


### PR DESCRIPTION
Links are not documented in convox.yml reference, and are even shown as a "generation1-only" feature. 

This PR proposes to add a `links` section in the convox.yml reference that links (no pun intended) to the `links` section in the gen1 reference. Although, it would probably be better to have a gen2 reference on linking as well.

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
