### PR TITLE
Running local commands should use `run` not `start`

### DIFF
--- a/_management/one-off-commands.md
+++ b/_management/one-off-commands.md
@@ -13,7 +13,7 @@ Convox allows you to execute individual commands on your containers in several d
 
 **To run a command in a local container...**
 
-* in a new container: `convox start [service] [command]`
+* in a new container: `convox run [service] [command]`
 * in a running container: There is no `convox` command for this. Use [`docker exec` instead](https://docs.docker.com/engine/reference/commandline/exec/).
 </div>
 


### PR DESCRIPTION
Running a one-off command locally is the same as on a remote rack. Update the docs to reflect that.

## Release Playbook
- [ ] Rebase against master
- [ ] Code review
- [ ] Merge into master
- [ ] Verify changes at http://site-staging.convox.com
- [ ] Promote release on `site-production` in the `convox/production` Rack
